### PR TITLE
Dockerfile script changed 

### DIFF
--- a/bentoml/saved_bundle/bundler.py
+++ b/bentoml/saved_bundle/bundler.py
@@ -123,11 +123,11 @@ def _write_bento_content_to_dir(bento_service, path):
         f.write(MANIFEST_IN_TEMPLATE.format(service_name=bento_service.name))
 
     # write Dockerfile
-    logger.debug("Using Docker Base Image %s", bento_service._env._docker_base_image)
+    logger.debug("Using Docker Base Image %s", bento_service._env._python_version)
     with open(os.path.join(path, "Dockerfile"), "w") as f:
         f.write(
             MODEL_SERVER_DOCKERFILE_CPU.format(
-                docker_base_image=bento_service._env._docker_base_image
+                python_version=bento_service._env._python_version
             )
         )
 

--- a/bentoml/saved_bundle/templates.py
+++ b/bentoml/saved_bundle/templates.py
@@ -69,54 +69,18 @@ graft {service_name}/artifacts
 """
 
 MODEL_SERVER_DOCKERFILE_CPU = """\
-FROM {docker_base_image}
+FROM python:{python_version}
 
-# Configure PIP install arguments, e.g. --index-url, --trusted-url, --extra-index-url
-ARG EXTRA_PIP_INSTALL_ARGS=
-ENV EXTRA_PIP_INSTALL_ARGS $EXTRA_PIP_INSTALL_ARGS
+COPY requirements.txt /
+RUN pip install -r ./requirements.txt --no-cache-dir
 
-ARG UID=1034
-ARG GID=1034
-RUN groupadd -g $GID -o bentoml && useradd -m -u $UID -g $GID -o -r bentoml
+COPY . /
 
-ARG BUNDLE_PATH=/home/bentoml/bundle
-ENV BUNDLE_PATH=$BUNDLE_PATH
-ENV BENTOML_HOME=/home/bentoml/
-
-RUN mkdir $BUNDLE_PATH && chown bentoml:bentoml $BUNDLE_PATH -R
-WORKDIR $BUNDLE_PATH
-
-# copy over the init script; copy over entrypoint scripts
-COPY --chown=bentoml:bentoml bentoml-init.sh docker-entrypoint.sh ./
-RUN chmod +x ./bentoml-init.sh
-
-# Copy docker-entrypoint.sh again, because setup.sh might not exist. This prevent COPY command from failing.
-COPY --chown=bentoml:bentoml docker-entrypoint.sh setup.s[h] ./
-RUN ./bentoml-init.sh custom_setup
-
-COPY --chown=bentoml:bentoml docker-entrypoint.sh python_versio[n] ./
-RUN ./bentoml-init.sh ensure_python
-
-COPY --chown=bentoml:bentoml environment.yml ./
-RUN ./bentoml-init.sh restore_conda_env
-
-COPY --chown=bentoml:bentoml requirements.txt ./
-RUN ./bentoml-init.sh install_pip_packages
-
-COPY --chown=bentoml:bentoml docker-entrypoint.sh bundled_pip_dependencie[s]  ./bundled_pip_dependencies/
-RUN rm ./bundled_pip_dependencies/docker-entrypoint.sh && ./bentoml-init.sh install_bundled_pip_packages
-
-# copy over model files
-COPY --chown=bentoml:bentoml . ./
-
-# the env var $PORT is required by heroku container runtime
 ENV PORT 5000
 EXPOSE $PORT
 
-USER bentoml
-RUN chmod +x ./docker-entrypoint.sh
-ENTRYPOINT [ "./docker-entrypoint.sh" ]
-CMD ["bentoml", "serve-gunicorn", "./"]
+CMD ["bentoml", "serve", "."]
+
 """  # noqa: E501
 
 INIT_PY_TEMPLATE = """\


### PR DESCRIPTION
- Changed DOCKERFILE automation script to use python as a base image.
- The python base image fetched will have the exact version of the user python version (even the minor version)  Eg. python: 3.7.7.
-  This script is not dependent on any of the shell scripts.
